### PR TITLE
Fix spacing in CTA button

### DIFF
--- a/articles/static-web-apps/application-settings.md
+++ b/articles/static-web-apps/application-settings.md
@@ -115,7 +115,7 @@ In a terminal or command line, execute the following command to delete a setting
 ## Next steps
 
 > [!div class="nextstepaction"]
-> [Define configuration for Azure Static Web Apps in the _staticwebapp.config.json_ file](configuration.md)
+> [Define configuration for Azure Static Web Apps in the  _staticwebapp.config.json_ file](configuration.md)
 
 ## Related articles
 

--- a/articles/static-web-apps/application-settings.md
+++ b/articles/static-web-apps/application-settings.md
@@ -115,7 +115,7 @@ In a terminal or command line, execute the following command to delete a setting
 ## Next steps
 
 > [!div class="nextstepaction"]
-> [Define configuration for Azure Static Web Apps in the  _staticwebapp.config.json_ file](configuration.md)
+> [Define configuration for Azure Static Web Apps in the  _staticwebapp.config.json_  file](configuration.md)
 
 ## Related articles
 


### PR DESCRIPTION
The current markdown isn't creating a space around the *staticwebapp.config.json*.

![image](https://github.com/jongalloway/azure-docs/assets/68539/877f3e61-a3db-4397-aa1f-5cf23aec459d)
